### PR TITLE
feat: static targetWidths functionality

### DIFF
--- a/test/test-buildSrcSet.mjs
+++ b/test/test-buildSrcSet.mjs
@@ -763,6 +763,13 @@ describe('SrcSet Builder:', function describeSuite() {
         });
       });
 
+      describe('with only default arguments', function describeSuite() {
+        it('targetWidths produces the default target width resolutions', function testSpec() {
+          const actual = ImgixClient.targetWidths();
+          assert.deepStrictEqual(actual, RESOLUTIONS);
+        });
+      });
+
       describe('with widthTolerance, minWidth, and maxWidth values which have caused duplicate values in the past', function describeSuite() {
         const client = new ImgixClient({
           domain: 'testing.imgix.net',


### PR DESCRIPTION
The purpose of this PR is to extend `targetWidths` functionality to
users via a static class function. A static function has been used to
preserve the import syntax for UMD, CommonJS, and ES6 modules.

Previously, this function was named `_generateTargetWidths` which
required users to instantiate an `ImgixClient` object to use it. Now,
this function has been renamed and re-implemented as a static function.

Previously, the parameter order required `widthTolerance`, `minWidth`,
and then `maxWidth`. The order has been changed in accordance with
how common a particular argument is expected to be passed:

```js
targetWidths(minWidth, maxWidth, widthTolerance, cache)
```
