### PR TITLE
chore(types): include targetWidths

### DIFF
--- a/src/imgix-js-core.d.ts
+++ b/src/imgix-js-core.d.ts
@@ -15,7 +15,7 @@ declare class ImgixClient {
     buildSrcSet(path: string, params?: {}, options?: SrcSetOptions): string;
     _buildSrcSetPairs(path: string, params?: {}, options?: SrcSetOptions): string;
     _buildDPRSrcSet(path: string, params?: {}, options?: SrcSetOptions): string;
-
+    targetWidths(minWidth?: number, maxWidth?: number, widthTolerance?: number, cache?: {}): number[];
 }    
 
 interface SrcSetOptions {


### PR DESCRIPTION
The purpose of this PR is to include the `targetWidths` function
in the `.d.ts` file. 