### PR TITLE
build: use prepare over deprecated prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build": "rollup -c",
     "compile": "cp ./src/imgix-js-core.d.ts ./dist/imgix-js-core.d.ts && tsc",
     "dev": "rollup -c -w",
-    "prepublish": "npm run build && npm run compile && npm run assert_version",
+    "prepare": "npm run build && npm run compile && npm run assert_version",
     "pretest": "npm run build",
     "pretty": "prettier --write '{src,test}/**/*.mjs'",
     "test": "mocha ./test/*.mjs",


### PR DESCRIPTION
The purpose of this PR is to change the prepublish-script to be named
as the prepare-script because [prepublish has been deprecated](https://docs.npmjs.com/cli/v7/using-npm/scripts#prepare-and-prepublish).

Since `npm@4.0.0`, `prepare`:
- runs any time before the package is packed, i.e. during npm publish and npm pack
- runs BEFORE the package is packed
- runs BEFORE the package is published
- runs on local npm install without any arguments