### PR TITLE
fix(targetWidths): validate minWidth, maxWidth, and widthTolerance

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,18 +1,17 @@
-import md5 from 'md5';
 import { Base64 } from 'js-base64';
-
+import md5 from 'md5';
 import {
-  VERSION,
-  DOMAIN_REGEX,
   DEFAULT_OPTIONS,
+  DOMAIN_REGEX,
   DPR_QUALITIES,
+  VERSION,
 } from './constants.mjs';
-
+import { ensureGreaterEqualThan } from './utils.mjs';
 import {
-  validateRange,
-  validateWidths,
   validateAndDestructureOptions,
+  validateRange,
   validateVariableQuality,
+  validateWidths,
   validateWidthTolerance,
 } from './validators.mjs';
 
@@ -119,7 +118,7 @@ export default class ImgixClient {
     widthTolerance = 0.08,
     cache = {},
   ) {
-    const minW = Math.floor(minWidth);
+    const minW = ensureGreaterEqualThan(1)(Math.floor(minWidth));
     const maxW = Math.floor(maxWidth);
     const cacheKey = widthTolerance + '/' + minW + '/' + maxW;
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -115,11 +115,12 @@ export default class ImgixClient {
   static targetWidths(
     minWidth = 100,
     maxWidth = 8192,
-    widthTolerance = 0.08,
+    _widthTolerance = 0.08,
     cache = {},
   ) {
     const minW = ensureGreaterEqualThan(1)(Math.floor(minWidth));
     const maxW = Math.floor(maxWidth);
+    const widthTolerance = ensureGreaterEqualThan(0.01)(_widthTolerance);
     const cacheKey = widthTolerance + '/' + minW + '/' + maxW;
 
     // First, check the cache.

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -1,0 +1,2 @@
+export const ensureGreaterEqualThan = (bound) => (data) =>
+  Math.max(bound, data);

--- a/test/test-buildSrcSet.mjs
+++ b/test/test-buildSrcSet.mjs
@@ -1,5 +1,5 @@
-import md5 from 'md5';
 import assert from 'assert';
+import md5 from 'md5';
 import ImgixClient from '../src/index.mjs';
 
 function assertWidthsIncreaseByTolerance(srcset, tolerance) {
@@ -794,6 +794,20 @@ describe('SrcSet Builder:', function describeSuite() {
             srcsetSplit[srcsetSplit.length - 2],
             srcsetSplit[srcsetSplit.length - 1],
           );
+        });
+      });
+
+      describe('with rogue parameters', () => {
+        describe('should not crash with minWidth < 1', () => {
+          it('0.99', () => {
+            ImgixClient.targetWidths(0.99);
+          });
+          it('0', () => {
+            ImgixClient.targetWidths(0);
+          });
+          it('-0.1', () => {
+            ImgixClient.targetWidths(-0.1);
+          });
         });
       });
     });

--- a/test/test-buildSrcSet.mjs
+++ b/test/test-buildSrcSet.mjs
@@ -809,6 +809,14 @@ describe('SrcSet Builder:', function describeSuite() {
             ImgixClient.targetWidths(-0.1);
           });
         });
+        describe('should not with widthTolerance <= 0', () => {
+          it('0', () => {
+            ImgixClient.targetWidths(1, 10, 0);
+          });
+          it('-0.5', () => {
+            ImgixClient.targetWidths(1, 10, -0.5);
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Passing a `minWidth` of e.g. `0.5` or a `widthTolerance` of 0 or less would cause Node to run out of memory before this change. I tested other cases but couldn't get the function to break, but there could still be potentially other ways of this function breaking.