### PR TITLE
fix: ensure undefined parameters not added to URL 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,14 +67,18 @@ export default class ImgixClient {
         : []),
 
       // Map over the key-value pairs in params while applying applicable encoding.
-      ...Object.entries(params).map(([key, value]) => {
+      ...Object.entries(params).reduce((prev, [key, value]) => {
+        if (value == null) {
+          return prev;
+        }
         const encodedKey = encodeURIComponent(key);
         const encodedValue =
           key.substr(-2) === '64'
             ? Base64.encodeURI(value)
             : encodeURIComponent(value);
-        return `${encodedKey}=${encodedValue}`;
-      }),
+        prev.push(`${encodedKey}=${encodedValue}`);
+        return prev;
+      }, []),
     ];
 
     return `${queryParams.length > 0 ? '?' : ''}${queryParams.join('&')}`;

--- a/test/test-buildURL.js
+++ b/test/test-buildURL.js
@@ -346,5 +346,13 @@ describe('URL Builder:', function describeSuite() {
 
       assert.strictEqual(actual, expected);
     });
+
+    it('should not include undefined parameters in url', function testSpect() {
+      const actual = client.buildURL('test.jpg', { ar: undefined, txt: null });
+      assert(!actual.includes('ar=undefined'));
+      assert(!actual.includes('ar=null'));
+      assert(!actual.includes('txt=undefined'));
+      assert(!actual.includes('txt=null'));
+    });
   });
 });


### PR DESCRIPTION
This PR ensures that undefined parameters are not added to the
params object generated by _buildParams. This way, undefined params do
not then end up in the generated URL.