### PR TITLE
(PoC) feat: add _buildURL static method

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,20 @@
+export function extractUrl({ url, options }) {
+  let prefix, rest, domain, _path, path;
+
+  const hasPrefix = url.indexOf('://') !== -1;
+  // store each component of the URL
+  if (!hasPrefix) {
+    prefix = options.useHTTPS ? 'https://' : 'http://';
+    [domain, ..._path] = url.split('/');
+  } else {
+    prefix = '';
+    rest = url.split('://')[1];
+    [domain, ..._path] = rest.split('/');
+  }
+  path = _path.join('/');
+  return {
+    prefix,
+    domain,
+    path,
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -75,19 +75,7 @@ export default class ImgixClient {
 
     const client = new ImgixClient({ domain, ...options });
 
-    if (options.sanitize) {
-      return client.buildURL(path, params);
-    } else {
-      // build the params string
-      let formattedParams = client._buildParams(params);
-      // sign the params string
-      if (!!client.settings.secureURLToken) {
-        formattedParams = client._signParams(path, formattedParams);
-      }
-
-      // return the url + params
-      return prefix + url + formattedParams;
-    }
+    return client.buildURL(path, params);
   }
 
   _buildParams(params = {}) {

--- a/test/test-_buildURL.js
+++ b/test/test-_buildURL.js
@@ -1,0 +1,90 @@
+import assert from 'assert';
+import ImgixClient from '../src/index.js';
+
+describe('URL Builder:', function describeSuite() {
+  describe('Calling _buildURL()', function describeSuite() {
+    let client, params, url, options;
+
+    beforeEach(function setupClient() {
+      client = ImgixClient;
+    });
+
+    describe('on a one-step URL', function describeSuite() {
+      url = 'https://assets.imgix.net/images/1.png';
+      params = { h: 100 };
+      options = { includeLibraryParam: false, useHTTPS: true };
+
+      it('should return a URL with formatted imgix params', function testSpec() {
+        const expectation = url + '?h=100';
+        const result = client._buildURL({
+          url,
+          params,
+          options,
+        });
+
+        assert.strictEqual(result, expectation);
+      });
+
+      it('should sanitize the URL path if sanitize option present', function testSpec() {
+        url = 'https://sdk-test.imgix.net/]!“#$%&‘()*+,-./:;<=>?@[]^_`{|}~.jpg';
+        options = { sanitize: true, includeLibraryParam: false };
+        params = {};
+        const expectation =
+          'https://sdk-test.imgix.net/%5D!%E2%80%9C%23$%25&%E2%80%98()*%2B,-./%3A;%3C=%3E%3F@%5B%5D%5E_%60%7B%7C%7D~.jpg';
+        const result = client._buildURL({
+          url,
+          params,
+          options,
+        });
+        assert.strictEqual(result, expectation);
+      });
+
+      describe('that has no scheme', function describeSuite() {
+        const url = 'assets.imgix.net/images/1.png';
+        const params = { h: 100 };
+        const options = { includeLibraryParam: false, useHTTPS: true };
+
+        it('should prepend the scheme to the returned URL', function testSpec() {
+          const expectation = 'https://' + url + '?h=100';
+          const result = client._buildURL({
+            url,
+            params,
+            options,
+          });
+
+          assert.strictEqual(result, expectation);
+        });
+      });
+    });
+
+    describe('on a malformed URLs', function describeSuite() {
+      const error = new Error(
+        '_buildURL: URL must match {host}/{path}?{query}',
+      );
+      const params = {};
+      const options = { includeLibraryParam: false, useHTTPS: true };
+
+      it('should throw an error if no hostname', function testSpec() {
+        const url = '/image.png';
+        assert.throws(function () {
+          client._buildURL({
+            url,
+            params,
+            options,
+          });
+        }, error);
+      });
+
+      it('should throw an error if no pathname', function testSpec() {
+        const url = 'assets.imgix.net';
+        assert.throws(function () {
+          client._buildURL({
+            url,
+            params,
+            options,
+          });
+        }, error);
+      });
+    });
+  });
+});


### PR DESCRIPTION
> This PR is a WIP
> This PR is a stacked PR

| PR 	| Title 	| Merges Into 	|   diff	|
|----	|-------	|-------------	|---	|
|    1	|    [_buildURL](https://github.com/imgix/js-core/pull/287) 👈🏼 	|           main     	|   [review this](https://github.com/imgix/js-core/pull/287/files)	|
|    2	|        [_buildSrcSet](https://github.com/imgix/js-core/pull/288)   	|           #287    	|   [review this](https://github.com/imgix/js-core/pull/288/files/2bddedfb20218fb975847427185ea30f3aac1a54..80806b276c58dc120784903ec5ac913e1bc311eb)	
|    3	|    [fix extractUrl](https://github.com/imgix/js-core/pull/290)  	|           #288     	|   [review this](https://github.com/imgix/js-core/pull/290/files/80806b276c58dc120784903ec5ac913e1bc311eb..096d101)	|

This PR creates the `_buildURL` static method on the ImgixClient. This methods allows us to use a 1-step, or full, URL to generate imgix formatted urls.

## Future work
Proxy URL tests are needed here. They're not being handled as of yet.