### PR TITLE
fix: remove "v" prefix from `VERSION` constant

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 // package version used in the ix-lib parameter
-export const VERSION = 'v3.1.3';
+export const VERSION = '3.1.3';
 // regex pattern used to determine if a domain is valid
 export const DOMAIN_REGEX = /^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/i;
 // minimum generated srcset width


### PR DESCRIPTION
The inclusion of the prefix (e.g. `ixlib=js-v3.1.3`) causes issues in our internal reporting that result in versions of this libray with the prefix to not be correctly captured. This commit removes the prefix to match the format previous to the current major version.