### PR TITLE
build: assert that versions match without relying on the "v" prefix

### DIFF
--- a/assert_version.cjs
+++ b/assert_version.cjs
@@ -1,7 +1,7 @@
 var packageVersion = require('./package').version;
 var ImgixClient = require('./dist/index.cjs.js');
 
-if (packageVersion === ImgixClient.version()) {
+if (packageVersion.includes(ImgixClient.version())) {
   return 0;
 } else {
   process.stdout.write(


### PR DESCRIPTION
#289 removed the "v" prefix from the src `VERSION` constant. The `assert_version` script confirms that the aforementioned constant matches that in the project package.json

Instead of relying on an exact string match, we can check that the src version (no prefix) is a subset of the package version (with prefix). In this way, `v3.0.0 == 3.0.0` will be true.

I debated removing the prefix from the package version as well but held off in case it somehow negatively affects in the future when we try to add semantic release in this project.