### PR TITLE
feat: full URL support for buildUrl and buildSrcSet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2058,6 +2058,7 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
       "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -4261,6 +4262,9 @@
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
       "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -4289,6 +4293,10 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4717,6 +4725,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -14003,6 +14012,7 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
           "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
           "dev": true,
+          "peer": true,
           "requires": {
             "cross-spawn": "^7.0.0",
             "get-stream": "^5.0.0",
@@ -15757,7 +15767,10 @@
       "version": "3.2.25",
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
       "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
     },
     "esprima": {
       "version": "4.0.1",
@@ -15775,7 +15788,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
     },
     "execa": {
       "version": "5.1.1",
@@ -16126,6 +16143,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "js-base64": "~3.6.0",
-        "md5": "^2.2.1"
+        "md5": "^2.2.1",
+        "ufo": "^0.7.5"
       },
       "devDependencies": {
         "@babel/core": "7.14.6",
@@ -12084,6 +12085,11 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/ufo": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.7.7.tgz",
+      "integrity": "sha512-N25aY3HBkJBnahm+2l4JRBBrX5I+JPakF/tDHYDTjd3wUR7iFLdyiPhj8mBwBz21v728BKwM9L9tgBfCntgdlw=="
+    },
     "node_modules/uglify-js": {
       "version": "3.13.10",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
@@ -21623,6 +21629,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
       "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
+    },
+    "ufo": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.7.7.tgz",
+      "integrity": "sha512-N25aY3HBkJBnahm+2l4JRBBrX5I+JPakF/tDHYDTjd3wUR7iFLdyiPhj8mBwBz21v728BKwM9L9tgBfCntgdlw=="
     },
     "uglify-js": {
       "version": "3.13.10",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "js-base64": "~3.6.0",
-    "md5": "^2.2.1"
+    "md5": "^2.2.1",
+    "ufo": "^0.7.5"
   },
   "devDependencies": {
     "@babel/core": "7.14.6",
@@ -56,74 +57,83 @@
   ],
   "release": {
     "branches": [
-    "main",
-    { "name": "@next", "prerelease": "rc" },
-    { "name": "beta", "prerelease": true },
-    { "name": "alpha", "prerelease": true }
-  ],
-  "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    [
-      "@google/semantic-release-replace-plugin",
+      "main",
       {
-        "replacements": [
-          {
-            "files": [
-              "src/constants.js"
-            ],
-            "from": "const VERSION = '.*'",
-            "to": "const VERSION = '${nextRelease.version}'",
-            "results": [
-              {
-                "file": "src/constants.js",
-                "hasChanged": true,
-                "numMatches": 1,
-                "numReplacements": 1
-              }
-            ],
-            "countMatches": true
-          }
-        ]
+        "name": "@next",
+        "prerelease": "rc"
+      },
+      {
+        "name": "beta",
+        "prerelease": true
+      },
+      {
+        "name": "alpha",
+        "prerelease": true
       }
     ],
-    "@semantic-release/changelog",
-    "@semantic-release/npm",
-    [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "src/**",
-          "dist/**",
-          "package.json",
-          "changelog.md"
-        ],
-        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes} [skip ci]"
-      }
-    ],
-    [
-      "@semantic-release/github",
-      {
-        "assets": [
-          {
-            "path": "dist/imgix-js-core.umd.js",
-            "label": "Standalone UMD build"
-          },
-          {
-            "path": "dist/index.cjs.js",
-            "label": "Standalone CJS build"
-          },
-          {
-            "path": "dist/index.esm.js",
-            "label": "Standalone ESM build"
-          },
-          {
-            "path": "dist/index.d.ts",
-            "label": "Type declarations file"
-          }
-        ]
-      }
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      [
+        "@google/semantic-release-replace-plugin",
+        {
+          "replacements": [
+            {
+              "files": [
+                "src/constants.js"
+              ],
+              "from": "const VERSION = '.*'",
+              "to": "const VERSION = '${nextRelease.version}'",
+              "results": [
+                {
+                  "file": "src/constants.js",
+                  "hasChanged": true,
+                  "numMatches": 1,
+                  "numReplacements": 1
+                }
+              ],
+              "countMatches": true
+            }
+          ]
+        }
+      ],
+      "@semantic-release/changelog",
+      "@semantic-release/npm",
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            "src/**",
+            "dist/**",
+            "package.json",
+            "changelog.md"
+          ],
+          "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes} [skip ci]"
+        }
+      ],
+      [
+        "@semantic-release/github",
+        {
+          "assets": [
+            {
+              "path": "dist/imgix-js-core.umd.js",
+              "label": "Standalone UMD build"
+            },
+            {
+              "path": "dist/index.cjs.js",
+              "label": "Standalone CJS build"
+            },
+            {
+              "path": "dist/index.esm.js",
+              "label": "Standalone ESM build"
+            },
+            {
+              "path": "dist/index.d.ts",
+              "label": "Type declarations file"
+            }
+          ]
+        }
+      ]
     ]
-  ]
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,9 +24,9 @@ export default [
   },
   {
     input: 'src/index.js',
-    external: ['md5', 'js-base64', 'assert'],
+    external: ['md5', 'js-base64', 'assert', 'ufo'],
     output: [
-      { file: pkg.main, format: 'cjs', exports: 'default'},
+      { file: pkg.main, format: 'cjs', exports: 'default' },
       { file: pkg.module, format: 'es', exports: 'default' },
     ],
     plugins: [

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,28 @@
+import { parseURL, hasProtocol } from 'ufo';
+
+/**
+ * `extractUrl()` extracts URL components from a source URL string.
+ * It does this by matching the URL against regular expressions. The irrelevant
+ * (entire URL) matches are removed and the rest stored as their corresponding
+ * URL components.
+ *
+ * `url` can be a partial, full URL, or full proxy URL. `useHttps` boolean
+ * defaults to false.
+ *
+ * @returns {Object} `{ protocol, auth, host, pathname, search, hash }`
+ * extracted from the URL.
+ */
+export function extractUrl({ url = '', useHttps = false }) {
+  const defaultProto = useHttps ? 'https://' : 'http://';
+  if (!hasProtocol(url, true)) {
+    return extractUrl({ url: defaultProto + url });
+  }
+  /**
+   * Regex are hard to parse. Leaving this breakdown here for reference.
+   * - `protocol`: ([^:/]+:)? - all not `:` or `/` & preceded by `:`, 0-1 times
+   * - `auth`: ([^/@]+@)? - all not `/` or `@` & preceded by `@`, 0-1 times
+   * - `domainAndPath`: (.*) /) -  all except line breaks
+   * - `domain`: `([^/]*)` - all before a `/` token
+   */
+  return parseURL(url);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -168,6 +168,42 @@ export default class ImgixClient {
     }
   }
 
+  /**
+   * _buildSrcSet static method allows full URLs to be used when generating
+   * imgix formatted `srcset` string values.
+   *
+   * - If the source URL has included parameters, they are merged with
+   * the `params` passed in as an argument.
+   * - URL must match `{host}/{pathname}?{query}` otherwise an error is thrown.
+   *
+   * @param {String} url - full source URL path string, required
+   * @param {Object} params - imgix params object, optional
+   * @param {Object} options - imgix client options, optional
+   * @returns imgix `srcset` for full URLs.
+   */
+  static _buildSrcSet(url, params = {}, options = {}) {
+    if (url == null) {
+      return '';
+    }
+
+    const { host, pathname, search } = extractUrl({
+      url,
+      useHTTPS: options.useHTTPS,
+    });
+    // merge source URL parameters with options parameters
+    const combinedParams = { ...getQuery(search), ...params };
+
+    // throw error if no host or no pathname present
+    if (!host.length || !pathname.length) {
+      throw new Error(
+        '_buildOneStepURL: URL must match {host}/{pathname}?{query}',
+      );
+    }
+
+    const client = new ImgixClient({ domain: host, ...options });
+    return client.buildSrcSet(pathname, combinedParams, options);
+  }
+
   // returns an array of width values used during srcset generation
   static targetWidths(
     minWidth = 100,

--- a/src/index.js
+++ b/src/index.js
@@ -178,17 +178,23 @@ export default class ImgixClient {
    *
    * @param {String} url - full source URL path string, required
    * @param {Object} params - imgix params object, optional
-   * @param {Object} options - imgix client options, optional
+   * @param {Object} srcsetModifiers - srcset modifiers, optional
+   * @param {Object} clientOptions - imgix client options, optional
    * @returns imgix `srcset` for full URLs.
    */
-  static _buildSrcSet(url, params = {}, options = {}) {
+  static _buildSrcSet(
+    url,
+    params = {},
+    srcsetModifiers = {},
+    clientOptions = {},
+  ) {
     if (url == null) {
       return '';
     }
 
     const { host, pathname, search } = extractUrl({
       url,
-      useHTTPS: options.useHTTPS,
+      useHTTPS: clientOptions.useHTTPS,
     });
     // merge source URL parameters with options parameters
     const combinedParams = { ...getQuery(search), ...params };
@@ -200,8 +206,8 @@ export default class ImgixClient {
       );
     }
 
-    const client = new ImgixClient({ domain: host, ...options });
-    return client.buildSrcSet(pathname, combinedParams, options);
+    const client = new ImgixClient({ domain: host, ...clientOptions });
+    return client.buildSrcSet(pathname, combinedParams, srcsetModifiers);
   }
 
   // returns an array of width values used during srcset generation

--- a/test/test-_buildSrcSet.js
+++ b/test/test-_buildSrcSet.js
@@ -1,0 +1,263 @@
+import md5 from 'md5';
+import assert from 'assert';
+import ImgixClient from '../src/index.js';
+
+function assertWidthsIncreaseByTolerance(srcset, tolerance) {
+  const srcsetWidths = srcset.split(',').map((u) => {
+    const tail = u.split(' ')[1];
+    const width = tail.slice(0, -1);
+    return Number.parseFloat(width);
+  });
+
+  // Make two equal sized arrays one for the numerators, e.g.
+  // [x1, x2, ..., xN] and another for the denominators, e.g.
+  // [x0, x1,..., x(N-1)].
+  const numerators = srcsetWidths.slice(1);
+  const denominators = srcsetWidths.slice(0, -1);
+
+  // Zip the numerator/denominator pairs.
+  const pairs = numerators.map((n, i) => {
+    return [n, denominators[i]];
+  });
+
+  // Be as tolerant as we can.
+  const tolerancePlus = tolerance + 0.004;
+
+  // Divide the zipped pairs, e.g. (x1 / x0), (x2 / x1)...
+  pairs.map((p) => {
+    assert(p[0] / p[1] - 1 < tolerancePlus);
+  });
+}
+
+function assertCorrectSigning(srcset, path, token) {
+  const _ = srcset.split(',').map((u) => {
+    // Split srcset into list of URLs.
+    const url = u.split(' ')[0];
+    assert(url.includes('s='));
+
+    // Get the signature without the otherParams.
+    const signature = url.slice(url.indexOf('s=') + 2, url.length);
+
+    // Use the otherParams, path, and token to create the expected signature.
+    const otherParams = url.slice(url.indexOf('?'), url.indexOf('s=') - 1);
+    const expected = md5(token + path + otherParams).toString();
+
+    assert.strictEqual(signature, expected);
+  });
+}
+
+function assertMinMaxWidthBounds(srcset, minBound, maxBound) {
+  const srcsetSplit = srcset.split(',');
+  const min = Number.parseFloat(srcsetSplit[0].split(' ')[1].slice(0, -1));
+  const max = Number.parseFloat(
+    srcsetSplit[srcsetSplit.length - 1].split(' ')[1].slice(0, -1),
+  );
+  assert(min >= minBound);
+  assert(max <= maxBound);
+}
+
+function assertCorrectWidthDescriptors(srcset, descriptors) {
+  const srcsetSplit = srcset.split(',');
+  srcsetSplit.map((u, i) => {
+    const width = parseInt(u.split(' ')[1].slice(0, -1), 10);
+    assert.strictEqual(width, descriptors[i]);
+  });
+}
+
+function assertIncludesQualities(srcset, qualities) {
+  srcset.split(',').map((u, i) => {
+    const url = u.split(' ')[0];
+    assert(url.includes(`q=${qualities[i]}`));
+  });
+}
+
+function assertIncludesQualityOverride(srcset, qOverride) {
+  srcset.split(',').map((u) => {
+    const url = u.split(' ')[0];
+    assert(url.includes(`q=${qOverride}`));
+  });
+}
+
+function assertIncludesDefaultDprParamAndDescriptor(srcset) {
+  const srcsetSplit = srcset.split(',');
+  assert.strictEqual(srcsetSplit.length, 5);
+
+  const parts = srcsetSplit.map((u) => u.split(' '));
+
+  // The firstParts contains the URLs without the width descriptors,
+  // i.e. ['https://test.imgix.net/image.jpg?dpr=1...',...]
+  const firstParts = parts.map((p) => p[0]);
+  firstParts.map((u, i) => {
+    assert(u.includes(`dpr=${i + 1}`));
+  });
+
+  // The lastParts contain the width descriptors without the URLs,
+  // i.e. [ '1x', '2x', '3x', '4x', '5x' ]
+  const lastParts = parts.map((p) => p[1]);
+  lastParts.map((d, i) => {
+    // assert 1x === `${0 + 1}x`, etc.
+    assert.strictEqual(d, `${i + 1}x`);
+  });
+}
+
+function assertDoesNotIncludeQuality(srcset) {
+  const _ = srcset.split(',').map((u) => {
+    const url = u.split(' ')[0];
+    assert(!url.includes(`q=`));
+  });
+}
+
+const RESOLUTIONS = [
+  100,
+  116,
+  135,
+  156,
+  181,
+  210,
+  244,
+  283,
+  328,
+  380,
+  441,
+  512,
+  594,
+  689,
+  799,
+  927,
+  1075,
+  1247,
+  1446,
+  1678,
+  1946,
+  2257,
+  2619,
+  3038,
+  3524,
+  4087,
+  4741,
+  5500,
+  6380,
+  7401,
+  8192,
+];
+
+describe('URL Builder:', function describeSuite() {
+  describe('Calling _buildSrcSet()', function describeSuite() {
+    let client, params, url, options;
+
+    describe('on a one-step URL', function describeSuite() {
+      url = 'https://testing.imgix.net/image.jpg';
+      options = {
+        includeLibraryParam: false,
+        useHTTPS: true,
+        secureURLToken: 'MYT0KEN',
+      };
+      client = ImgixClient;
+      const srcset = client._buildSrcSet(url, params, options);
+
+      describe('with no parameters', function describeSuite() {
+        params = {};
+        it('should generate the expected default srcset pair values', function testSpec() {
+          assertCorrectWidthDescriptors(srcset, RESOLUTIONS);
+        });
+
+        it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
+          assert.strictEqual(srcset.split(',').length, 31);
+        });
+
+        it('should not exceed the bounds of [100, 8192]', function testSpec() {
+          assertMinMaxWidthBounds(srcset, 100, 8192);
+        });
+
+        // a 17% testing threshold is used to account for rounding
+        it('should not increase more than 17% every iteration', function testSpec() {
+          assertWidthsIncreaseByTolerance(srcset, 0.17);
+        });
+
+        it('should correctly sign each URL', function testSpec() {
+          assertCorrectSigning(srcset, '/image.jpg', 'MYT0KEN');
+        });
+      });
+
+      describe('with a width parameter provided', function describeSuite() {
+        params = { w: 100 };
+        const DPR_QUALITY = [75, 50, 35, 23, 20];
+        const srcset = client._buildSrcSet(url, params, options);
+
+        it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
+          assertIncludesDefaultDprParamAndDescriptor(srcset);
+        });
+
+        it('should correctly sign each URL', function testSpec() {
+          assertCorrectSigning(srcset, '/image.jpg', 'MYT0KEN');
+        });
+
+        it('should include a dpr param per specified src', function testSpec() {
+          assertIncludesDefaultDprParamAndDescriptor(srcset);
+        });
+
+        it('should include variable qualities by default', function testSpec() {
+          assertIncludesQualities(srcset, DPR_QUALITY);
+        });
+
+        it('should override variable quality if quality parameter provided', function testSpec() {
+          const QUALITY_OVERRIDE = 100;
+          params = { w: 800, q: QUALITY_OVERRIDE };
+          const srcset = client._buildSrcSet(url, params, options);
+
+          assertIncludesQualityOverride(srcset, QUALITY_OVERRIDE);
+        });
+
+        it("should disable variable qualities if 'disableVariableQuality'", function testSpec() {
+          params = { w: 800 };
+          options = { ...options, disableVariableQuality: true };
+          const srcset = client._buildSrcSet(url, params, options);
+          assertDoesNotIncludeQuality(srcset);
+        });
+
+        it('should respect quality param when variable qualities disabled', function testSpec() {
+          const QUALITY_OVERRIDE = 100;
+          params = { w: 800, q: QUALITY_OVERRIDE };
+          options = { ...options, disableVariableQuality: true };
+          const srcset = client._buildSrcSet(url, params, options);
+          assertIncludesQualityOverride(srcset, QUALITY_OVERRIDE);
+        });
+      });
+
+      describe('using srcset parameters', function describeSuite() {
+        describe('with a minWidth and/or maxWidth provided', function describeSuite() {
+          const MIN = 500;
+          const MAX = 2000;
+          params = {};
+          options = { ...options, minWidth: MIN, maxWidth: MAX };
+          const srcset = client._buildSrcSet(url, params, options);
+
+          it('should return correct number of `url widthDescriptor` pairs', function testSpec() {
+            assert.strictEqual(srcset.split(',').length, 11);
+          });
+
+          it('should generate the default srcset pair values', function testSpec() {
+            const resolutions = [
+              500,
+              580,
+              673,
+              780,
+              905,
+              1050,
+              1218,
+              1413,
+              1639,
+              1901,
+              2000,
+            ];
+            assertCorrectWidthDescriptors(srcset, resolutions);
+          });
+
+          it('should not exceed the bounds of [100, 8192]', function testSpec() {
+            assertMinMaxWidthBounds(srcset, 100, 8192);
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/test-_buildSrcSet.js
+++ b/test/test-_buildSrcSet.js
@@ -143,17 +143,23 @@ const RESOLUTIONS = [
 
 describe('URL Builder:', function describeSuite() {
   describe('Calling _buildSrcSet()', function describeSuite() {
-    let client, params, url, options;
+    let client, params, url, srcsetModifiers, clientOptions;
 
     describe('on a one-step URL', function describeSuite() {
       url = 'https://testing.imgix.net/image.jpg';
-      options = {
+      clientOptions = {
         includeLibraryParam: false,
         useHTTPS: true,
         secureURLToken: 'MYT0KEN',
       };
+      srcsetModifiers = {};
       client = ImgixClient;
-      const srcset = client._buildSrcSet(url, params, options);
+      const srcset = client._buildSrcSet(
+        url,
+        params,
+        srcsetModifiers,
+        clientOptions,
+      );
 
       describe('with no parameters', function describeSuite() {
         params = {};
@@ -182,7 +188,12 @@ describe('URL Builder:', function describeSuite() {
       describe('with a width parameter provided', function describeSuite() {
         params = { w: 100 };
         const DPR_QUALITY = [75, 50, 35, 23, 20];
-        const srcset = client._buildSrcSet(url, params, options);
+        const srcset = client._buildSrcSet(
+          url,
+          params,
+          srcsetModifiers,
+          clientOptions,
+        );
 
         it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
           assertIncludesDefaultDprParamAndDescriptor(srcset);
@@ -203,23 +214,38 @@ describe('URL Builder:', function describeSuite() {
         it('should override variable quality if quality parameter provided', function testSpec() {
           const QUALITY_OVERRIDE = 100;
           params = { w: 800, q: QUALITY_OVERRIDE };
-          const srcset = client._buildSrcSet(url, params, options);
+          const srcset = client._buildSrcSet(
+            url,
+            params,
+            srcsetModifiers,
+            clientOptions,
+          );
 
           assertIncludesQualityOverride(srcset, QUALITY_OVERRIDE);
         });
 
         it("should disable variable qualities if 'disableVariableQuality'", function testSpec() {
           params = { w: 800 };
-          options = { ...options, disableVariableQuality: true };
-          const srcset = client._buildSrcSet(url, params, options);
+          srcsetModifiers = { disableVariableQuality: true };
+          const srcset = client._buildSrcSet(
+            url,
+            params,
+            srcsetModifiers,
+            clientOptions,
+          );
           assertDoesNotIncludeQuality(srcset);
         });
 
         it('should respect quality param when variable qualities disabled', function testSpec() {
           const QUALITY_OVERRIDE = 100;
           params = { w: 800, q: QUALITY_OVERRIDE };
-          options = { ...options, disableVariableQuality: true };
-          const srcset = client._buildSrcSet(url, params, options);
+          srcsetModifiers = { disableVariableQuality: true };
+          const srcset = client._buildSrcSet(
+            url,
+            params,
+            srcsetModifiers,
+            clientOptions,
+          );
           assertIncludesQualityOverride(srcset, QUALITY_OVERRIDE);
         });
       });
@@ -229,8 +255,13 @@ describe('URL Builder:', function describeSuite() {
           const MIN = 500;
           const MAX = 2000;
           params = {};
-          options = { ...options, minWidth: MIN, maxWidth: MAX };
-          const srcset = client._buildSrcSet(url, params, options);
+          srcsetModifiers = { minWidth: MIN, maxWidth: MAX };
+          const srcset = client._buildSrcSet(
+            url,
+            params,
+            srcsetModifiers,
+            clientOptions,
+          );
 
           it('should return correct number of `url widthDescriptor` pairs', function testSpec() {
             assert.strictEqual(srcset.split(',').length, 11);

--- a/test/test-_buildURL.js
+++ b/test/test-_buildURL.js
@@ -1,0 +1,119 @@
+import assert from 'assert';
+import ImgixClient from '../src/index.js';
+
+describe('URL Builder:', function describeSuite() {
+  describe('Calling _buildURL()', function describeSuite() {
+    let client, params, url, options;
+
+    beforeEach(function setupClient() {
+      client = ImgixClient;
+    });
+
+    describe('on a full URL', function describeSuite() {
+      url = 'https://assets.imgix.net/images/1.png';
+      params = { h: 100 };
+      options = { includeLibraryParam: false, useHTTPS: true };
+
+      it('should return a URL with formatted imgix params', function testSpec() {
+        const expectation = url + '?h=100';
+        const result = client._buildURL(url, params, options);
+
+        assert.strictEqual(result, expectation);
+      });
+
+      describe('that has no scheme', function describeSuite() {
+        const url = 'assets.imgix.net/images/1.png';
+        const params = {};
+        const options = { includeLibraryParam: false, useHTTPS: true };
+
+        it('should prepend the scheme to the returned URL', function testSpec() {
+          const expectation = 'https://' + url;
+          const result = client._buildURL(url, params, options);
+
+          assert.strictEqual(result, expectation);
+        });
+      });
+
+      describe('that has a proxy path', function describeSuite() {
+        const url = 'https://assets.imgix.net/https://sdk-test/images/1.png';
+        const params = {};
+        const options = { includeLibraryParam: false, useHTTPS: true };
+
+        it('should correctly encode the proxy path', function testSpec() {
+          const expectation = new client({
+            domain: 'assets.imgix.net',
+            ...options,
+          }).buildURL('https://sdk-test/images/1.png', params);
+          const result = client._buildURL(url, params, options);
+
+          assert.strictEqual(result, expectation);
+        });
+      });
+
+      describe('that has a insecure source and secure proxy', function describeSuite() {
+        const url =
+          'http://assets.imgix.net/https://sdk-test.imgix.net/images/1.png';
+        const params = {};
+        const options = { includeLibraryParam: false, useHTTPS: false };
+
+        it('should not modify the source or proxy schemes', function testSpec() {
+          const expectation =
+            'http://assets.imgix.net/https%3A%2F%2Fsdk-test.imgix.net%2Fimages%2F1.png';
+          const result = client._buildURL(url, params, options);
+
+          assert.strictEqual(result, expectation);
+        });
+      });
+
+      describe('that has a secure source and insecure proxy', function describeSuite() {
+        const url =
+          'https://assets.imgix.net/http://sdk-test.imgix.net/images/1.png';
+        const params = {};
+        const options = { includeLibraryParam: false, useHTTPS: true };
+
+        it('should not modify the source or proxy schemes', function testSpec() {
+          const expectation =
+            'https://assets.imgix.net/http%3A%2F%2Fsdk-test.imgix.net%2Fimages%2F1.png';
+          const result = client._buildURL(url, params, options);
+
+          assert.strictEqual(result, expectation);
+        });
+      });
+    });
+
+    describe('on a malformed URLs', function describeSuite() {
+      const error = new Error(
+        '_buildURL: URL must match {host}/{pathname}?{query}',
+      );
+      const params = {};
+      const options = { includeLibraryParam: false, useHTTPS: true };
+
+      it('should throw an error if no hostname', function testSpec() {
+        const url = '/image.png';
+        assert.throws(function () {
+          client._buildURL(url, params, options);
+        }, error);
+      });
+
+      it('should throw an error if no pathname', function testSpec() {
+        const url = 'assets.imgix.net';
+        assert.throws(function () {
+          client._buildURL(url, params, options);
+        }, error);
+      });
+    });
+
+    describe('that has parameters in the URL', function describeSuite() {
+      const url = 'https://assets.imgix.net/images/1.png?w=100&h=100';
+      const params = { h: 200 };
+      const options = { includeLibraryParam: false, useHTTPS: true };
+
+      it('should overwrite url params with opts params', function testSpec() {
+        const expectation = 'https://assets.imgix.net/images/1.png?w=100&h=200';
+        const result = client._buildURL(url, params, options);
+
+        assert.strictEqual(result, expectation);
+      });
+    });
+  });
+});

--- a/test/test-extractURL.js
+++ b/test/test-extractURL.js
@@ -1,0 +1,97 @@
+import assert from 'assert';
+import { extractUrl } from '../src/helpers.js';
+
+describe('extractURL', () => {
+  describe('For non-proxy path URLs', () => {
+    const image = 'https://assets.imgix.net/bridge.jpg?w=100';
+    const expectation = {
+      host: 'assets.imgix.net',
+      pathname: '/bridge.jpg',
+      search: '?w=100',
+    };
+    const result = extractUrl({ url: image });
+    it('should extract a host from URL', () => {
+      assert.strictEqual(result.host, expectation.host);
+    });
+    it('should extract a pathname from URL', () => {
+      assert.strictEqual(result.pathname, expectation.pathname);
+    });
+    it('should extract existing query from URL', () => {
+      assert.strictEqual(result.search, expectation.search);
+    });
+  });
+  describe('For proxy path URLs', () => {
+    it('should extract a proxy path from full URLs', () => {
+      const proxyPath =
+        'https://assets.imgix.net/https://sdk-test.imgix.net/amsterdam.jpg';
+      const result = extractUrl({ url: proxyPath });
+      const expectation = {
+        host: 'assets.imgix.net',
+        pathname: '/https://sdk-test.imgix.net/amsterdam.jpg',
+      };
+      assert.strictEqual(result.host, expectation.host);
+      assert.strictEqual(result.pathname, expectation.pathname);
+    });
+
+    it('should extract a proxy path from partial URLs', () => {
+      const proxyPath =
+        'assets.imgix.net/https://sdk-test.imgix.net/amsterdam.jpg';
+      const result = extractUrl({ url: proxyPath });
+      const expectation = {
+        host: 'assets.imgix.net',
+        pathname: '/https://sdk-test.imgix.net/amsterdam.jpg',
+      };
+      assert.strictEqual(result.host, expectation.host);
+      assert.strictEqual(result.pathname, expectation.pathname);
+    });
+
+    it('should not modify proxy scheme', () => {
+      const proxyPath =
+        'https://assets.imgix.net/http://sdk-test.imgix.net/amsterdam.jpg';
+      const result = extractUrl({
+        url: proxyPath,
+        options: { useHttps: true },
+      });
+      const expectation = {
+        host: 'assets.imgix.net',
+        pathname: '/http://sdk-test.imgix.net/amsterdam.jpg',
+      };
+      assert.strictEqual(result.host, expectation.host);
+      assert.strictEqual(result.pathname, expectation.pathname);
+    });
+
+    it('should prepend source scheme when missing', () => {
+      const proxyPath =
+        'assets.imgix.net/http://sdk-test.imgix.net/amsterdam.jpg';
+      const result = extractUrl({
+        url: proxyPath,
+        options: { useHttps: false },
+      });
+      const expectation = {
+        protocol: 'http:',
+        host: 'assets.imgix.net',
+        pathname: '/http://sdk-test.imgix.net/amsterdam.jpg',
+      };
+      assert.strictEqual(result.protocol, expectation.protocol);
+      assert.strictEqual(result.host, expectation.host);
+      assert.strictEqual(result.pathname, expectation.pathname);
+    });
+
+    it('should use https for source when defined in options', () => {
+      const proxyPath =
+        'assets.imgix.net/http://sdk-test.imgix.net/amsterdam.jpg';
+      const result = extractUrl({
+        url: proxyPath,
+        useHttps: true,
+      });
+      const expectation = {
+        protocol: 'https:',
+        host: 'assets.imgix.net',
+        pathname: '/http://sdk-test.imgix.net/amsterdam.jpg',
+      };
+      assert.strictEqual(result.protocol, expectation.protocol);
+      assert.strictEqual(result.host, expectation.host);
+      assert.strictEqual(result.pathname, expectation.pathname);
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,9 +12,11 @@ declare class ImgixClient {
   });
 
   buildURL(path: string, params?: {}): string;
+  static _buildURL(path: string, params?: {}, options?: {}): string;
   _sanitizePath(path: string): string;
   _buildParams(params: {}): string;
   _signParams(path: string, queryParams?: {}): string;
+  static _buildSrcSet(path: string, params?: {}, options?: {}): string;
   buildSrcSet(path: string, params?: {}, options?: SrcSetOptions): string;
   _buildSrcSetPairs(path: string, params?: {}, options?: SrcSetOptions): string;
   _buildDPRSrcSet(path: string, params?: {}, options?: SrcSetOptions): string;


### PR DESCRIPTION
This PR adds full URL support to the client via static methods

-  `_buildURL` 
- `_buildSrcSet`

Unit tests for these methods are included in the PR.

The PR also introduces a helper function, `extractUrl` that uses the `ufo` module to parse and isolate different URL components of a full URL. Unit tests for the helper function are also included in the PR.

The PR also introduces `ufo` [package](https://github.com/unjs/ufo) as a dependency.

## Examples

```js
const client = ImgixClient
const params = { w: 100 }
const opts = { useHttps: true }
const src = "sdk-test.imgix.net/amsterdam.jpg?h=100"

const url = client._buildURL(src, params, opts)
const srcSet = client._buildSrcSet(src, params, opts)

console.log(url) // => "https://sdk-test.imgix.net/amsterdam.jpg?h=100&w=100"
console.log(srcSet) /** =>
* https://sdk-test.imgix.net/amsterdam.jpg?w=800&q=100&dpr=1&s=f556bd48d069e6435d8f59940fbd2830 1x,
* https://sdk-test.imgix.net/amsterdam.jpg?w=100&h=100&dpr=2 2x,
* https://sdk-test.imgix.net/amsterdam.jpg?w=100&h=100&&dpr=3 3x,
* https://sdk-test.imgix.net/amsterdam.jpg?w=100&h=100&dpr=4 4x,
* https://sdk-test.imgix.net/amsterdam.jpg?w=100&h=100&dpr=5 5x"
*/
```

## Future Work
- There are edge cases that might be missing from the unit tests. Please comment on the PR if any come to mind.
- These methods could be exported as named exports to avoid having to call `client.{method}`. This can be added in a subsequent PR if needed.

## Comments

This PR is not considered a breaking change since none of the existing public methods are changed.

This PR includes work and feedback from:
- #287 
- #288 
- #290 

> Please note that support for full URLs is considered experimental and will not be officially supported.