### PR TITLE
fix: add missing types to `_buildSrcSet` type declaration

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,7 +16,12 @@ declare class ImgixClient {
   _sanitizePath(path: string): string;
   _buildParams(params: {}): string;
   _signParams(path: string, queryParams?: {}): string;
-  static _buildSrcSet(path: string, params?: {}, options?: {}): string;
+  static _buildSrcSet(
+    path: string,
+    params?: {},
+    srcSetOptions?: {},
+    clientOptions?: {},
+  ): string;
   buildSrcSet(path: string, params?: {}, options?: SrcSetOptions): string;
   _buildSrcSetPairs(path: string, params?: {}, options?: SrcSetOptions): string;
   _buildDPRSrcSet(path: string, params?: {}, options?: SrcSetOptions): string;


### PR DESCRIPTION
Adds the following missing types to `types/index.d.ts`
```js
// * @param {Object} srcsetModifiers - srcset modifiers, optional
// * @param {Object} clientOptions - imgix client options, optional
```

So that `_buildSrcSet` types are defined as
```ts
  static _buildSrcSet(
    path: string,
    params?: {},
    srcSetOptions?: {},
    clientOptions?: {},
  ): string;
```