### PR TITLE
feat: allow path encoding to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@
     * [In-browser](#in-browser)
 - [Configuration](#configuration)
 - [API](#api)
-    * [`ImgixClient.buildURL(path, params)`](#imgixclientbuildurlpath-params)
+    * [`ImgixClient.buildURL(path, params, options)`](#imgixclientbuildurlpath-params-options)
     * [`ImgixClient.buildSrcSet(path, params, options)`](#imgixclientbuildsrcsetpath-params-options)
         + [Fixed Image Rendering](#fixed-image-rendering)
         + [Custom Widths](#custom-widths)
         + [Width Tolerance](#width-tolerance)
         + [Minimum and Maximum Width Ranges](#minimum-and-maximum-width-ranges)
         + [Variable Qualities](#variable-qualities)
+        + [Disable Path Encoding](#disable-path-encoding)
     * [Web Proxy Sources](#web-proxy-sources)
 - [What is the `Ixlib` Param on Every Request?](#what-is-the-ixlib-param-on-every-request)
 - [Testing](#testing)
@@ -109,10 +110,12 @@ The following options can be used when creating an instance of `ImgixClient`:
 
 ## API
 
-### `ImgixClient.buildURL(path, params)`
+### `ImgixClient.buildURL(path, params, options)`
 
 - **`path`:** String, required. A full, unencoded path to the image. This includes any additional directory information required to [locate the image](https://docs.imgix.com/setup/serving-images) within a source.
 - **`params`:** Object. Any number of imgix rendering API [parameters](https://docs.imgix.com/apis/url).
+- **`options`:** Object. Any number of modifiers, described below:
+  - [**`disablePathEncoding`**](#disable-path-encoding)
 
 Construct a single image URL by passing in the image `path` and any rendering API parameters.
 
@@ -146,6 +149,7 @@ https://testing.imgix.net/folder/image.jpg?w=1000&ixlib=js-...
   - [**`disableVariableQuality`**](#variable-qualities)
   - [**`devicePixelRatios`**](#fixed-image-rendering)
   - [**`variableQualities`**](#variable-qualities)
+  - [**`disablePathEncoding`**](#disable-path-encoding)
 
 <!-- prettier-ignore-end -->
 
@@ -240,8 +244,10 @@ console.log(srcset);
 Will result in a smaller srcset.
 
 ```html
-https://testing.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=1&s=3d754a157458402fd3e26977107ade74 1x,
-https://testing.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=2&s=a984ad1a81d24d9dd7d18195d5262c82 2x
+https://testing.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=1&s=3d754a157458402fd3e26977107ade74
+1x,
+https://testing.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=2&s=a984ad1a81d24d9dd7d18195d5262c82
+2x
 ```
 
 For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.
@@ -401,6 +407,32 @@ https://testing.imgix.net/image.jpg?w=100&dpr=3&q=20 3x,
 https://testing.imgix.net/image.jpg?w=100&dpr=4&q=15 4x,
 https://testing.imgix.net/image.jpg?w=100&dpr=5&q=10 5x
 ```
+
+#### Disable Path Encoding
+
+This library will encode by default all paths passed to both `buildURL` and `buildSrcSet` methods. To disable path encoding, pass `{ disablePathEncoding: true }` to the third argument `options` of `buildURL()` or `buildSrcSet()`.
+
+```js
+const client = new ImgixClient({
+  domain: 'testing.imgix.net',
+});
+
+const src = client.buildURL(
+  'file+with%20some+crazy?things.jpg',
+  {},
+  { disablePathEncoding: true },
+);
+console.log(src);
+
+const srcset = client.buildSrcSet(
+  'file+with%20some+crazy?things.jpg',
+  {},
+  { disablePathEncoding: true },
+);
+console.log(srcset);
+```
+
+Normally this would output a src of `https://sdk-test.imgix.net/file%2Bwith%2520some%2Bcrazy%3Fthings.jpg`, but since path encoding is disabled, it will output a src of `https://sdk-test.imgix.net/file+with%20some+crazy?things.jpg`.
 
 ### Web Proxy Sources
 

--- a/test/test-pathEncoding.js
+++ b/test/test-pathEncoding.js
@@ -35,5 +35,73 @@ describe('Path Encoding:', function describeSuite() {
 
       assert.strictEqual(actual, expected);
     });
+
+    it('passes through a path unencoded if disablePathEncoding is set', () => {
+      const actual = client.buildURL(
+        '/file+with%20some+crazy?things.jpg',
+        {},
+        {
+          disablePathEncoding: true,
+        },
+      );
+
+      const expected =
+        'https://sdk-test.imgix.net/file+with%20some+crazy?things.jpg';
+      assert.strictEqual(actual, expected);
+    });
+  });
+  describe('buildSrcSet', () => {
+    let client;
+
+    beforeEach(function setupClient() {
+      client = new ImgixClient({
+        domain: 'sdk-test.imgix.net',
+        includeLibraryParam: false,
+      });
+    });
+    it('passes through a path unencoded for a fixed srcset if disablePathEncoding is set', () => {
+      const actual = client.buildSrcSet(
+        '/file+with%20some+crazy?things.jpg',
+        {
+          w: 100,
+        },
+        {
+          disablePathEncoding: true,
+        },
+      );
+
+      const expected =
+        'https://sdk-test.imgix.net/file+with%20some+crazy?things.jpg';
+      assert(actual.includes(expected), 'srcset should include expected url');
+    });
+    it('passes through a path unencoded for a fixed srcset if disablePathEncoding and disableVariableQuality is set', () => {
+      const actual = client.buildSrcSet(
+        '/file+with%20some+crazy?things.jpg',
+        {
+          w: 100,
+        },
+        {
+          disablePathEncoding: true,
+          disableVariableQuality: true,
+        },
+      );
+
+      const expected =
+        'https://sdk-test.imgix.net/file+with%20some+crazy?things.jpg';
+      assert(actual.includes(expected), 'srcset should include expected url');
+    });
+    it('passes through a path unencoded for a fluid srcset if disablePathEncoding is set', () => {
+      const actual = client.buildSrcSet(
+        '/file+with%20some+crazy?things.jpg',
+        {},
+        {
+          disablePathEncoding: true,
+        },
+      );
+
+      const expected =
+        'https://sdk-test.imgix.net/file+with%20some+crazy?things.jpg';
+      assert(actual.includes(expected), 'srcset should include expected url');
+    });
   });
 });

--- a/test/test-pathEncoding.js
+++ b/test/test-pathEncoding.js
@@ -49,6 +49,19 @@ describe('Path Encoding:', function describeSuite() {
         'https://sdk-test.imgix.net/file+with%20some+crazy?things.jpg';
       assert.strictEqual(actual, expected);
     });
+    it('prepends / to path when disablePathEncoding is set', () => {
+      const actual = client.buildURL(
+        'file+with%20some+crazy?things.jpg',
+        {},
+        {
+          disablePathEncoding: true,
+        },
+      );
+
+      const expected =
+        'https://sdk-test.imgix.net/file+with%20some+crazy?things.jpg';
+      assert(actual.includes(expected), 'srcset should include expected url');
+    });
   });
   describe('buildSrcSet', () => {
     let client;
@@ -93,6 +106,19 @@ describe('Path Encoding:', function describeSuite() {
     it('passes through a path unencoded for a fluid srcset if disablePathEncoding is set', () => {
       const actual = client.buildSrcSet(
         '/file+with%20some+crazy?things.jpg',
+        {},
+        {
+          disablePathEncoding: true,
+        },
+      );
+
+      const expected =
+        'https://sdk-test.imgix.net/file+with%20some+crazy?things.jpg';
+      assert(actual.includes(expected), 'srcset should include expected url');
+    });
+    it('prepends / to path when disablePathEncoding is set', () => {
+      const actual = client.buildSrcSet(
+        'file+with%20some+crazy?things.jpg',
         {},
         {
           disablePathEncoding: true,

--- a/test/test-pathEncoding.js
+++ b/test/test-pathEncoding.js
@@ -62,6 +62,25 @@ describe('Path Encoding:', function describeSuite() {
         'https://sdk-test.imgix.net/file+with%20some+crazy?things.jpg';
       assert(actual.includes(expected), 'srcset should include expected url');
     });
+    it('signs a pre-encoded path correctly', () => {
+      const client = new ImgixClient({
+        domain: 'sdk-test.imgix.net',
+        secureURLToken: 'abcde1234',
+        includeLibraryParam: false,
+      });
+      const actual = client.buildURL(
+        'file+with%20some+crazy%20things.jpg',
+        {},
+        {
+          disablePathEncoding: true,
+        },
+      );
+
+      // The signing param for this URL was taken from a known working implementation
+      const expected =
+        'https://sdk-test.imgix.net/file+with%20some+crazy%20things.jpg?s=4aadfc1a58f27729a41d05831c52116f';
+      assert.strictEqual(actual, expected);
+    });
   });
   describe('buildSrcSet', () => {
     let client;
@@ -128,6 +147,27 @@ describe('Path Encoding:', function describeSuite() {
       const expected =
         'https://sdk-test.imgix.net/file+with%20some+crazy?things.jpg';
       assert(actual.includes(expected), 'srcset should include expected url');
+    });
+    it('signs a pre-encoded path correctly', () => {
+      const client = new ImgixClient({
+        domain: 'sdk-test.imgix.net',
+        secureURLToken: 'abcde1234',
+        includeLibraryParam: false,
+      });
+      const actual = client.buildSrcSet(
+        'file+with%20some+crazy%20things.jpg',
+        {},
+        {
+          disablePathEncoding: true,
+        },
+      );
+
+      // The signing param for this URL was taken from a known working implementation
+      const expected = '524748753f8aa52fb41b9359f79c3188';
+      const firstURLSignature = new URL(
+        actual.split(',')[0].split(' ')[0],
+      ).searchParams.get('s');
+      assert.strictEqual(firstURLSignature, expected);
     });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,7 +11,11 @@ declare class ImgixClient {
     includeLibraryParam?: boolean;
   });
 
-  buildURL(path: string, params?: {}): string;
+  buildURL(
+    path: string,
+    params?: {},
+    options?: { disablePathEncoding?: boolean },
+  ): string;
   _sanitizePath(path: string): string;
   _buildParams(params: {}): string;
   _signParams(path: string, queryParams?: {}): string;
@@ -38,6 +42,7 @@ export interface SrcSetOptions {
   disableVariableQuality?: boolean;
   devicePixelRatios?: DevicePixelRatio[];
   variableQualities?: VariableQualities;
+  disablePathEncoding?: boolean;
 }
 
 export default ImgixClient;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -17,8 +17,11 @@ params = { w: 100 };
 
 expectType<string>(client.buildURL(path, params));
 
+const buildURLOptions = {
+  disablePathEncoding: true,
+};
 params = {};
-expectType<string>(client.buildURL('foo/bar/baz', params));
+expectType<string>(client.buildURL('foo/bar/baz', params, buildURLOptions));
 
 expectType<string>(client._sanitizePath(path));
 
@@ -26,7 +29,7 @@ expectType<string>(client._buildParams(params));
 
 expectType<string>(client._signParams(path, params));
 
-const options: SrcSetOptions = {
+const srcsetOptions: SrcSetOptions = {
   widths: [100, 500, 1000],
   widthTolerance: 0.05,
   minWidth: 500,
@@ -37,19 +40,20 @@ const options: SrcSetOptions = {
     1: 45,
     2: 30,
   },
+  disablePathEncoding: true,
 };
 
 expectType<string>(client.buildSrcSet(path));
 expectType<string>(client.buildSrcSet(path, params));
-expectType<string>(client.buildSrcSet(path, params, options));
+expectType<string>(client.buildSrcSet(path, params, srcsetOptions));
 
 expectType<string>(client._buildSrcSetPairs(path));
 expectType<string>(client._buildSrcSetPairs(path, params));
-expectType<string>(client._buildSrcSetPairs(path, params, options));
+expectType<string>(client._buildSrcSetPairs(path, params, srcsetOptions));
 
 expectType<string>(client._buildDPRSrcSet(path));
 expectType<string>(client._buildDPRSrcSet(path, params));
-expectType<string>(client._buildDPRSrcSet(path, params, options));
+expectType<string>(client._buildDPRSrcSet(path, params, srcsetOptions));
 
 const minWidth = 200;
 const maxWidth = 1000;


### PR DESCRIPTION
Before this PR, this library would encode all paths passed to either `buildURL` or `buildSrcSet`. This was a great default in a lot of scenarios, but this proved to be irritating when integrating with some data sources that provided already encoded URL paths. Thus, this PR allows this path encoding behavior to be disabled in the `options` parameter for both methods.
