### PR TITLE
feat: add _buildURL and _buildSrcSet static methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@imgix/js-core",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@imgix/js-core",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "js-base64": "~3.7.0",
-        "md5": "^2.2.1"
+        "md5": "^2.2.1",
+        "ufo": "^0.7.10"
       },
       "devDependencies": {
         "@babel/core": "7.17.5",
@@ -8110,11 +8111,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10291,6 +10287,11 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/ufo": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.7.10.tgz",
+      "integrity": "sha512-YTnDRlE1cIofRqOFN8ioAbz9qenDvkgVMSn0cnxvIDjM9sfEOMKB0ybMr+otSlCXMfQ/X35haYRoI7Nua82RrA=="
     },
     "node_modules/uglify-js": {
       "version": "3.15.1",
@@ -18227,6 +18228,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
+    },
+    "ufo": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.7.10.tgz",
+      "integrity": "sha512-YTnDRlE1cIofRqOFN8ioAbz9qenDvkgVMSn0cnxvIDjM9sfEOMKB0ybMr+otSlCXMfQ/X35haYRoI7Nua82RrA=="
     },
     "uglify-js": {
       "version": "3.15.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "js-base64": "~3.7.0",
-    "md5": "^2.2.1"
+    "md5": "^2.2.1",
+    "ufo": "^0.7.10"
   },
   "devDependencies": {
     "@babel/core": "7.17.5",
@@ -45,6 +46,7 @@
     "pretest": "npm run build",
     "pretty": "prettier --write '{src,test,types}/**/*.{js,ts}'",
     "test": "mocha --require esm --recursive ./test/*.js && npm run tsd",
+    "test:watch": "mocha --require esm --recursive ./test/*.js --watch",
     "test:performance": "mocha --require esm --recursive test/performance/*.js",
     "tsd": "echo Running tsd; tsd",
     "release:dryRun": "npx node-env-run --exec 'semantic-release --dryRun'",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,28 @@
+import { parseURL, hasProtocol } from 'ufo';
+
+/**
+ * `extractUrl()` extracts URL components from a source URL string.
+ * It does this by matching the URL against regular expressions. The irrelevant
+ * (entire URL) matches are removed and the rest stored as their corresponding
+ * URL components.
+ *
+ * `url` can be a partial, full URL, or full proxy URL. `useHttps` boolean
+ * defaults to false.
+ *
+ * @returns {Object} `{ protocol, auth, host, pathname, search, hash }`
+ * extracted from the URL.
+ */
+export function extractUrl({ url = '', useHttps = false }) {
+  const defaultProto = useHttps ? 'https://' : 'http://';
+  if (!hasProtocol(url, true)) {
+    return extractUrl({ url: defaultProto + url });
+  }
+  /**
+   * Regex are hard to parse. Leaving this breakdown here for reference.
+   * - `protocol`: ([^:/]+:)? - all not `:` or `/` & preceded by `:`, 0-1 times
+   * - `auth`: ([^/@]+@)? - all not `/` or `@` & preceded by `@`, 0-1 times
+   * - `domainAndPath`: (.*) /) -  all except line breaks
+   * - `domain`: `([^/]*)` - all before a `/` token
+   */
+  return parseURL(url);
+}

--- a/test/test-_buildSrcSet.js
+++ b/test/test-_buildSrcSet.js
@@ -1,0 +1,294 @@
+import md5 from 'md5';
+import assert from 'assert';
+import ImgixClient from '../src/index.js';
+
+function assertWidthsIncreaseByTolerance(srcset, tolerance) {
+  const srcsetWidths = srcset.split(',').map((u) => {
+    const tail = u.split(' ')[1];
+    const width = tail.slice(0, -1);
+    return Number.parseFloat(width);
+  });
+
+  // Make two equal sized arrays one for the numerators, e.g.
+  // [x1, x2, ..., xN] and another for the denominators, e.g.
+  // [x0, x1,..., x(N-1)].
+  const numerators = srcsetWidths.slice(1);
+  const denominators = srcsetWidths.slice(0, -1);
+
+  // Zip the numerator/denominator pairs.
+  const pairs = numerators.map((n, i) => {
+    return [n, denominators[i]];
+  });
+
+  // Be as tolerant as we can.
+  const tolerancePlus = tolerance + 0.004;
+
+  // Divide the zipped pairs, e.g. (x1 / x0), (x2 / x1)...
+  pairs.map((p) => {
+    assert(p[0] / p[1] - 1 < tolerancePlus);
+  });
+}
+
+function assertCorrectSigning(srcset, path, token) {
+  const _ = srcset.split(',').map((u) => {
+    // Split srcset into list of URLs.
+    const url = u.split(' ')[0];
+    assert(url.includes('s='));
+
+    // Get the signature without the otherParams.
+    const signature = url.slice(url.indexOf('s=') + 2, url.length);
+
+    // Use the otherParams, path, and token to create the expected signature.
+    const otherParams = url.slice(url.indexOf('?'), url.indexOf('s=') - 1);
+    const expected = md5(token + path + otherParams).toString();
+
+    assert.strictEqual(signature, expected);
+  });
+}
+
+function assertMinMaxWidthBounds(srcset, minBound, maxBound) {
+  const srcsetSplit = srcset.split(',');
+  const min = Number.parseFloat(srcsetSplit[0].split(' ')[1].slice(0, -1));
+  const max = Number.parseFloat(
+    srcsetSplit[srcsetSplit.length - 1].split(' ')[1].slice(0, -1),
+  );
+  assert(min >= minBound);
+  assert(max <= maxBound);
+}
+
+function assertCorrectWidthDescriptors(srcset, descriptors) {
+  const srcsetSplit = srcset.split(',');
+  srcsetSplit.map((u, i) => {
+    const width = parseInt(u.split(' ')[1].slice(0, -1), 10);
+    assert.strictEqual(width, descriptors[i]);
+  });
+}
+
+function assertIncludesQualities(srcset, qualities) {
+  srcset.split(',').map((u, i) => {
+    const url = u.split(' ')[0];
+    assert(url.includes(`q=${qualities[i]}`));
+  });
+}
+
+function assertIncludesQualityOverride(srcset, qOverride) {
+  srcset.split(',').map((u) => {
+    const url = u.split(' ')[0];
+    assert(url.includes(`q=${qOverride}`));
+  });
+}
+
+function assertIncludesDefaultDprParamAndDescriptor(srcset) {
+  const srcsetSplit = srcset.split(',');
+  assert.strictEqual(srcsetSplit.length, 5);
+
+  const parts = srcsetSplit.map((u) => u.split(' '));
+
+  // The firstParts contains the URLs without the width descriptors,
+  // i.e. ['https://test.imgix.net/image.jpg?dpr=1...',...]
+  const firstParts = parts.map((p) => p[0]);
+  firstParts.map((u, i) => {
+    assert(u.includes(`dpr=${i + 1}`));
+  });
+
+  // The lastParts contain the width descriptors without the URLs,
+  // i.e. [ '1x', '2x', '3x', '4x', '5x' ]
+  const lastParts = parts.map((p) => p[1]);
+  lastParts.map((d, i) => {
+    // assert 1x === `${0 + 1}x`, etc.
+    assert.strictEqual(d, `${i + 1}x`);
+  });
+}
+
+function assertDoesNotIncludeQuality(srcset) {
+  const _ = srcset.split(',').map((u) => {
+    const url = u.split(' ')[0];
+    assert(!url.includes(`q=`));
+  });
+}
+
+const RESOLUTIONS = [
+  100,
+  116,
+  135,
+  156,
+  181,
+  210,
+  244,
+  283,
+  328,
+  380,
+  441,
+  512,
+  594,
+  689,
+  799,
+  927,
+  1075,
+  1247,
+  1446,
+  1678,
+  1946,
+  2257,
+  2619,
+  3038,
+  3524,
+  4087,
+  4741,
+  5500,
+  6380,
+  7401,
+  8192,
+];
+
+describe('URL Builder:', function describeSuite() {
+  describe('Calling _buildSrcSet()', function describeSuite() {
+    let client, params, url, srcsetModifiers, clientOptions;
+
+    describe('on a one-step URL', function describeSuite() {
+      url = 'https://testing.imgix.net/image.jpg';
+      clientOptions = {
+        includeLibraryParam: false,
+        useHTTPS: true,
+        secureURLToken: 'MYT0KEN',
+      };
+      srcsetModifiers = {};
+      client = ImgixClient;
+      const srcset = client._buildSrcSet(
+        url,
+        params,
+        srcsetModifiers,
+        clientOptions,
+      );
+
+      describe('with no parameters', function describeSuite() {
+        params = {};
+        it('should generate the expected default srcset pair values', function testSpec() {
+          assertCorrectWidthDescriptors(srcset, RESOLUTIONS);
+        });
+
+        it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
+          assert.strictEqual(srcset.split(',').length, 31);
+        });
+
+        it('should not exceed the bounds of [100, 8192]', function testSpec() {
+          assertMinMaxWidthBounds(srcset, 100, 8192);
+        });
+
+        // a 17% testing threshold is used to account for rounding
+        it('should not increase more than 17% every iteration', function testSpec() {
+          assertWidthsIncreaseByTolerance(srcset, 0.17);
+        });
+
+        it('should correctly sign each URL', function testSpec() {
+          assertCorrectSigning(srcset, '/image.jpg', 'MYT0KEN');
+        });
+      });
+
+      describe('with a width parameter provided', function describeSuite() {
+        params = { w: 100 };
+        const DPR_QUALITY = [75, 50, 35, 23, 20];
+        const srcset = client._buildSrcSet(
+          url,
+          params,
+          srcsetModifiers,
+          clientOptions,
+        );
+
+        it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
+          assertIncludesDefaultDprParamAndDescriptor(srcset);
+        });
+
+        it('should correctly sign each URL', function testSpec() {
+          assertCorrectSigning(srcset, '/image.jpg', 'MYT0KEN');
+        });
+
+        it('should include a dpr param per specified src', function testSpec() {
+          assertIncludesDefaultDprParamAndDescriptor(srcset);
+        });
+
+        it('should include variable qualities by default', function testSpec() {
+          assertIncludesQualities(srcset, DPR_QUALITY);
+        });
+
+        it('should override variable quality if quality parameter provided', function testSpec() {
+          const QUALITY_OVERRIDE = 100;
+          params = { w: 800, q: QUALITY_OVERRIDE };
+          const srcset = client._buildSrcSet(
+            url,
+            params,
+            srcsetModifiers,
+            clientOptions,
+          );
+
+          assertIncludesQualityOverride(srcset, QUALITY_OVERRIDE);
+        });
+
+        it("should disable variable qualities if 'disableVariableQuality'", function testSpec() {
+          params = { w: 800 };
+          srcsetModifiers = { disableVariableQuality: true };
+          const srcset = client._buildSrcSet(
+            url,
+            params,
+            srcsetModifiers,
+            clientOptions,
+          );
+          assertDoesNotIncludeQuality(srcset);
+        });
+
+        it('should respect quality param when variable qualities disabled', function testSpec() {
+          const QUALITY_OVERRIDE = 100;
+          params = { w: 800, q: QUALITY_OVERRIDE };
+          srcsetModifiers = { disableVariableQuality: true };
+          const srcset = client._buildSrcSet(
+            url,
+            params,
+            srcsetModifiers,
+            clientOptions,
+          );
+          assertIncludesQualityOverride(srcset, QUALITY_OVERRIDE);
+        });
+      });
+
+      describe('using srcset parameters', function describeSuite() {
+        describe('with a minWidth and/or maxWidth provided', function describeSuite() {
+          const MIN = 500;
+          const MAX = 2000;
+          params = {};
+          srcsetModifiers = { minWidth: MIN, maxWidth: MAX };
+          const srcset = client._buildSrcSet(
+            url,
+            params,
+            srcsetModifiers,
+            clientOptions,
+          );
+
+          it('should return correct number of `url widthDescriptor` pairs', function testSpec() {
+            assert.strictEqual(srcset.split(',').length, 11);
+          });
+
+          it('should generate the default srcset pair values', function testSpec() {
+            const resolutions = [
+              500,
+              580,
+              673,
+              780,
+              905,
+              1050,
+              1218,
+              1413,
+              1639,
+              1901,
+              2000,
+            ];
+            assertCorrectWidthDescriptors(srcset, resolutions);
+          });
+
+          it('should not exceed the bounds of [100, 8192]', function testSpec() {
+            assertMinMaxWidthBounds(srcset, 100, 8192);
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/test-_buildURL.js
+++ b/test/test-_buildURL.js
@@ -1,0 +1,119 @@
+import assert from 'assert';
+import ImgixClient from '../src/index.js';
+
+describe('URL Builder:', function describeSuite() {
+  describe('Calling _buildURL()', function describeSuite() {
+    let client, params, url, options;
+
+    beforeEach(function setupClient() {
+      client = ImgixClient;
+    });
+
+    describe('on a full URL', function describeSuite() {
+      url = 'https://assets.imgix.net/images/1.png';
+      params = { h: 100 };
+      options = { includeLibraryParam: false, useHTTPS: true };
+
+      it('should return a URL with formatted imgix params', function testSpec() {
+        const expectation = url + '?h=100';
+        const result = client._buildURL(url, params, options);
+
+        assert.strictEqual(result, expectation);
+      });
+
+      describe('that has no scheme', function describeSuite() {
+        const url = 'assets.imgix.net/images/1.png';
+        const params = {};
+        const options = { includeLibraryParam: false, useHTTPS: true };
+
+        it('should prepend the scheme to the returned URL', function testSpec() {
+          const expectation = 'https://' + url;
+          const result = client._buildURL(url, params, options);
+
+          assert.strictEqual(result, expectation);
+        });
+      });
+
+      describe('that has a proxy path', function describeSuite() {
+        const url = 'https://assets.imgix.net/https://sdk-test/images/1.png';
+        const params = {};
+        const options = { includeLibraryParam: false, useHTTPS: true };
+
+        it('should correctly encode the proxy path', function testSpec() {
+          const expectation = new client({
+            domain: 'assets.imgix.net',
+            ...options,
+          }).buildURL('https://sdk-test/images/1.png', params);
+          const result = client._buildURL(url, params, options);
+
+          assert.strictEqual(result, expectation);
+        });
+      });
+
+      describe('that has a insecure source and secure proxy', function describeSuite() {
+        const url =
+          'http://assets.imgix.net/https://sdk-test.imgix.net/images/1.png';
+        const params = {};
+        const options = { includeLibraryParam: false, useHTTPS: false };
+
+        it('should not modify the source or proxy schemes', function testSpec() {
+          const expectation =
+            'http://assets.imgix.net/https%3A%2F%2Fsdk-test.imgix.net%2Fimages%2F1.png';
+          const result = client._buildURL(url, params, options);
+
+          assert.strictEqual(result, expectation);
+        });
+      });
+
+      describe('that has a secure source and insecure proxy', function describeSuite() {
+        const url =
+          'https://assets.imgix.net/http://sdk-test.imgix.net/images/1.png';
+        const params = {};
+        const options = { includeLibraryParam: false, useHTTPS: true };
+
+        it('should not modify the source or proxy schemes', function testSpec() {
+          const expectation =
+            'https://assets.imgix.net/http%3A%2F%2Fsdk-test.imgix.net%2Fimages%2F1.png';
+          const result = client._buildURL(url, params, options);
+
+          assert.strictEqual(result, expectation);
+        });
+      });
+    });
+
+    describe('on a malformed URLs', function describeSuite() {
+      const error = new Error(
+        '_buildURL: URL must match {host}/{pathname}?{query}',
+      );
+      const params = {};
+      const options = { includeLibraryParam: false, useHTTPS: true };
+
+      it('should throw an error if no hostname', function testSpec() {
+        const url = '/image.png';
+        assert.throws(function () {
+          client._buildURL(url, params, options);
+        }, error);
+      });
+
+      it('should throw an error if no pathname', function testSpec() {
+        const url = 'assets.imgix.net';
+        assert.throws(function () {
+          client._buildURL(url, params, options);
+        }, error);
+      });
+    });
+
+    describe('that has parameters in the URL', function describeSuite() {
+      const url = 'https://assets.imgix.net/images/1.png?w=100&h=100';
+      const params = { h: 200 };
+      const options = { includeLibraryParam: false, useHTTPS: true };
+
+      it('should overwrite url params with opts params', function testSpec() {
+        const expectation = 'https://assets.imgix.net/images/1.png?w=100&h=200';
+        const result = client._buildURL(url, params, options);
+
+        assert.strictEqual(result, expectation);
+      });
+    });
+  });
+});

--- a/test/test-extractURL.js
+++ b/test/test-extractURL.js
@@ -1,0 +1,97 @@
+import assert from 'assert';
+import { extractUrl } from '../src/helpers.js';
+
+describe('extractURL', () => {
+  describe('For non-proxy path URLs', () => {
+    const image = 'https://assets.imgix.net/bridge.jpg?w=100';
+    const expectation = {
+      host: 'assets.imgix.net',
+      pathname: '/bridge.jpg',
+      search: '?w=100',
+    };
+    const result = extractUrl({ url: image });
+    it('should extract a host from URL', () => {
+      assert.strictEqual(result.host, expectation.host);
+    });
+    it('should extract a pathname from URL', () => {
+      assert.strictEqual(result.pathname, expectation.pathname);
+    });
+    it('should extract existing query from URL', () => {
+      assert.strictEqual(result.search, expectation.search);
+    });
+  });
+  describe('For proxy path URLs', () => {
+    it('should extract a proxy path from full URLs', () => {
+      const proxyPath =
+        'https://assets.imgix.net/https://sdk-test.imgix.net/amsterdam.jpg';
+      const result = extractUrl({ url: proxyPath });
+      const expectation = {
+        host: 'assets.imgix.net',
+        pathname: '/https://sdk-test.imgix.net/amsterdam.jpg',
+      };
+      assert.strictEqual(result.host, expectation.host);
+      assert.strictEqual(result.pathname, expectation.pathname);
+    });
+
+    it('should extract a proxy path from partial URLs', () => {
+      const proxyPath =
+        'assets.imgix.net/https://sdk-test.imgix.net/amsterdam.jpg';
+      const result = extractUrl({ url: proxyPath });
+      const expectation = {
+        host: 'assets.imgix.net',
+        pathname: '/https://sdk-test.imgix.net/amsterdam.jpg',
+      };
+      assert.strictEqual(result.host, expectation.host);
+      assert.strictEqual(result.pathname, expectation.pathname);
+    });
+
+    it('should not modify proxy scheme', () => {
+      const proxyPath =
+        'https://assets.imgix.net/http://sdk-test.imgix.net/amsterdam.jpg';
+      const result = extractUrl({
+        url: proxyPath,
+        options: { useHttps: true },
+      });
+      const expectation = {
+        host: 'assets.imgix.net',
+        pathname: '/http://sdk-test.imgix.net/amsterdam.jpg',
+      };
+      assert.strictEqual(result.host, expectation.host);
+      assert.strictEqual(result.pathname, expectation.pathname);
+    });
+
+    it('should prepend source scheme when missing', () => {
+      const proxyPath =
+        'assets.imgix.net/http://sdk-test.imgix.net/amsterdam.jpg';
+      const result = extractUrl({
+        url: proxyPath,
+        options: { useHttps: false },
+      });
+      const expectation = {
+        protocol: 'http:',
+        host: 'assets.imgix.net',
+        pathname: '/http://sdk-test.imgix.net/amsterdam.jpg',
+      };
+      assert.strictEqual(result.protocol, expectation.protocol);
+      assert.strictEqual(result.host, expectation.host);
+      assert.strictEqual(result.pathname, expectation.pathname);
+    });
+
+    it('should use https for source when defined in options', () => {
+      const proxyPath =
+        'assets.imgix.net/http://sdk-test.imgix.net/amsterdam.jpg';
+      const result = extractUrl({
+        url: proxyPath,
+        useHttps: true,
+      });
+      const expectation = {
+        protocol: 'https:',
+        host: 'assets.imgix.net',
+        pathname: '/http://sdk-test.imgix.net/amsterdam.jpg',
+      };
+      assert.strictEqual(result.protocol, expectation.protocol);
+      assert.strictEqual(result.host, expectation.host);
+      assert.strictEqual(result.pathname, expectation.pathname);
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,6 +28,13 @@ declare class ImgixClient {
     widthTolerance?: number,
     cache?: {},
   ): number[];
+  static _buildURL(path: string, params?: {}, options?: {}): string;
+  static _buildSrcSet(
+    path: string,
+    params?: {},
+    srcSetOptions?: {},
+    clientOptions?: {},
+  ): string;
 }
 
 export type DevicePixelRatio = 1 | 2 | 3 | 4 | 5 | number;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -68,3 +68,14 @@ expectType<number[]>(ImgixClient.targetWidths(minWidth, maxWidth, widthTol));
 expectType<number[]>(
   ImgixClient.targetWidths(minWidth, maxWidth, widthTol, cache),
 );
+
+const absoluteURL = 'https://test.imgix.net/image.jpg';
+
+expectType<string>(ImgixClient._buildURL(absoluteURL, params, {}));
+expectType<string>(ImgixClient._buildURL(absoluteURL, params, buildURLOptions));
+
+expectType<string>(ImgixClient._buildSrcSet(absoluteURL));
+expectType<string>(ImgixClient._buildSrcSet(absoluteURL, params));
+expectType<string>(
+  ImgixClient._buildSrcSet(absoluteURL, params, srcsetOptions),
+);


### PR DESCRIPTION
This PR creates static `_buildURL` and `_buildSrcSet` methods on the imgix client. These methods allow absolute URLs to be formatted for use with the imgix client.

- _buildURL

```
   *`_buildURL` static method allows full URLs to be formatted for use with
   * imgix.
   *
   * - If the source URL has included parameters, they are merged with
   * the `params` passed in as an argument.
   * - URL must match `{host}/{pathname}?{query}` otherwise an error is thrown.
```

- _buildSrcSet:    

```
   * _buildSrcSet static method allows full URLs to be used when generating
   * imgix formatted `srcset` string values.
   *
   * - If the source URL has included parameters, they are merged with
   * the `params` passed in as an argument.
   * - URL must match `{host}/{pathname}?{query}` otherwise an error is thrown.
  ```