### PR TITLE
docs(readme): additional warning about the `secureURLToken` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ The following options can be used when creating an instance of `ImgixClient`:
 - **`useHTTPS`:** Boolean. Specifies whether constructed URLs should use the HTTPS protocol. Defaults to `true`.
 - **`includeLibraryParam`:** Boolean. Specifies whether the constructed URLs will include an [`ixlib` parameter](#what-is-the-ixlib-param-on-every-request). Defaults to `true`.
 - **`secureURLToken`:** String. When specified, this token will be used to sign images. Read more about securing images [on the imgix Docs site](https://docs.imgix.com/setup/securing-images). Defaults to `null`.
+  - :warning: *The `secureURLToken` option should only be used in server-side applications to prevent exposing your secure token.* :warning:
+
 
 ## API
 


### PR DESCRIPTION
# Description
Added a warning about using the `secureURLToken` option only on the server. In doing so, I realized there's a similar warning in the browser example right above it. 🤷

## Checklist: Fixing typos/Doc change

- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: e.g. `chore(readme): fix typo`. See the end of this file for more information.
