### PR TITLE
chore(types): remove top level options

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,9 +1,4 @@
 declare class ImgixClient {
-  domain: string;
-  useHTTPS: boolean;
-  includeLibraryParam: boolean;
-  secureURLToken: string;
-
   constructor(opts: {
     domain: string;
     secureURLToken?: string;


### PR DESCRIPTION
This commit removed incorrect type declarations that exposed top-level settings as client properties. These options should only be used inside the constructor or as function arguments for static methods.