### PR TITLE
ci(build): test if builds are successful during ci test step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,12 @@ jobs:
       - checkout
       - node/install-packages
       - run: npm run test
+      - run:
+          name: "Test that build is successful"
+          command: npm run build
+      - run:
+          name: "Test that compile is successful"
+          command: npm run compile
   deploy:
     docker:
       - image: cimg/node:current


### PR DESCRIPTION
Adds an additional test step to our CircleCI process to test successful builds.

# Before
Problems with builds can only be detected by CircleCI during the deploy step; this step only runs on `main` and prerelease branches. As a result, commits that break builds (included automated dependency updates by Renovate) in many cases might not be detected until after merge.

# After
We now test for a successful build step on every branch, using both stable and LTS node versions.