### PR TITLE
ci(deploy): add prepublishOnly step

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "compile": "cp ./types/index.d.ts ./dist/index.d.ts && tsc",
     "dev": "rollup -c -w",
     "prepare": "npm run build && npm run compile && npm run assert_version",
+    "prepublishOnly": "npm run build && npm run compile && npm run assert_version",
     "pretest": "npm run build",
     "pretty": "prettier --write '{src,test,types}/**/*.{js,ts}'",
     "test": "mocha --require esm --recursive ./test/*.js && npm run tsd",


### PR DESCRIPTION
Adds additional script to ensure properly updated `dist` prior to release.

# Before

Library is not guaranteed to execute a `build` step to properly update `dist` directory prior to deployment; as a result, some libraries include the prior release in their `dist` folder.

# After

We include both a `prepare` and a `prepublishOnly` step to ensure that the library executes a build prior to deploying a release.
