### PR TITLE
chore: clean up `Disable Path Encoding` code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ const srcset = client.buildSrcSet(
 console.log(srcset);
 ```
 
-Normally this would output a src of `https://sdk-test.imgix.net/file%2Bwith%2520some%2Bcrazy%3Fthings.jpg`, but since path encoding is disabled, it will output a src of `https://sdk-test.imgix.net/file+with%20some+crazy?things.jpg`.
+Normally this would output a src of `https://testing.imgix.net/file%2Bwith%2520some%2Bcrazy%3Fthings.jpg`, but since path encoding is disabled, it will output a src of `https://testing.imgix.net/file+with%20some+crazy?things.jpg`.
 
 ### Web Proxy Sources
 


### PR DESCRIPTION
Fixes an inconsistency in the `Disable Path Encoding` documentation. The code example uses `domain: 'testing.imgix.net'` but the returned URL showed `https://sdk-test.imgix.net/...`.

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [ ] ~~Update or add any necessary API documentation (if applicable)~~
- [x] All existing unit tests are still passing (if applicable).
