### PR TITLE
fix(deps): update ufo to 1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "js-base64": "~3.7.0",
         "md5": "^2.2.1",
-        "ufo": "^0.8.0"
+        "ufo": "^1.0.0"
       },
       "devDependencies": {
         "@babel/core": "7.20.5",
@@ -8081,6 +8081,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10217,9 +10222,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.5.tgz",
-      "integrity": "sha512-e4+UtA5IRO+ha6hYklwj6r7BjiGMxS0O+UaSg9HbaTefg4kMkzj4tXzEBajRR+wkxf+golgAWKzLbytCUDMJAA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
+      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA=="
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",
@@ -18114,9 +18119,9 @@
       "dev": true
     },
     "ufo": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.5.tgz",
-      "integrity": "sha512-e4+UtA5IRO+ha6hYklwj6r7BjiGMxS0O+UaSg9HbaTefg4kMkzj4tXzEBajRR+wkxf+golgAWKzLbytCUDMJAA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
+      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA=="
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "js-base64": "~3.7.0",
     "md5": "^2.2.1",
-    "ufo": "^0.8.0"
+    "ufo": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.20.5",


### PR DESCRIPTION
## Descriptions

This PR updates the `ufo` dependency to the next major release, [`1.0.1`](https://github.com/unjs/ufo/compare/v0.8.0...v1.0.1)

Closes #348 

