### PR TITLE
fix: apply custom encoder to base64 parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ The following options can be used when creating an instance of `ImgixClient`:
 - **`path`:** String, required. A full, unencoded path to the image. This includes any additional directory information required to [locate the image](https://docs.imgix.com/setup/serving-images) within a source.
 - **`params`:** Object. Any number of imgix rendering API [parameters](https://docs.imgix.com/apis/url).
 - **`options`:** Object. Any number of modifiers, described below:
-  - [**`disablePathEncoding`**](#disable-path-encoding)
-  - [**`encoder`**](#encoder)
+  - [**`disablePathEncoding`**](#disable-path-encoding): Boolean. Disables encoding logic applied to the image path.
+  - [**`encoder`**](#encoder): Function. Applies custom logic to encode the image path and query parameters.
 
 Construct a single image URL by passing in the image `path` and any rendering API parameters.
 
@@ -432,7 +432,7 @@ Normally this would output a src of `https://testing.imgix.net/file%2Bwith%2520s
 
 ### Custom URL encoding
 
-This library will encode by default using `encodeURI()`,  `encodeURIComponent()`, or a combination of the two depending on the image path and parameters. 
+This library will encode by default using `encodeURI()`,  `encodeURIComponent()`, or a combination of the two depending on the image path and parameters.
 You can define a custom encoding function in `buildURL's `options` object **if** you wish to override this behavior. Note that encoding your own URL can result in a URL that is **not** recognized by the imgix rendering API.
 
 ```js
@@ -457,6 +457,26 @@ client.buildURL(
   https://proxy.imgix.net/image.jpg?txt=test!(%27)
 */
 
+```
+
+The custom encoder also accepts a second optional parameter `key` which allows users to modify how query parameters are encoded. This parameter does not affect the custom encoding logic of the image path.
+
+```js
+const ImgixClient = require("@imgix/js-core");
+const client = new ImgixClient({
+  domain: 'test.imgix.com',
+  secureURLToken: 'xxxxxxxx',
+});
+
+client.buildURL(
+  "https://proxy.imgix.net/image.jpg",
+  {
+    "txt": "test!(')*"
+  },
+  {
+    encoder: (value, key) => key?.substr(-2) === '64' ? Base64.encodeURI(value) : value.replace(' ', "+")
+  }
+)
 ```
 
 ### Web Proxy Sources

--- a/src/index.js
+++ b/src/index.js
@@ -119,11 +119,11 @@ export default class ImgixClient {
         if (value == null) {
           return prev;
         }
-        const encodedKey = useCustomEncoder ? customEncoder(key) : encodeURIComponent(key);
+        const encodedKey = useCustomEncoder ? customEncoder(key, value) : encodeURIComponent(key);
         const encodedValue =
           key.substr(-2) === '64'
-          ? useCustomEncoder ? customEncoder(value) : Base64.encodeURI(value)
-          : useCustomEncoder ? customEncoder(value) : encodeURIComponent(value);
+          ? useCustomEncoder ? customEncoder(value, key) : Base64.encodeURI(value)
+          : useCustomEncoder ? customEncoder(value, key) : encodeURIComponent(value);
         prev.push(`${encodedKey}=${encodedValue}`);
 
         return prev;

--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,8 @@ export default class ImgixClient {
   _buildParams(params = {}, options = {}) {
     // If a custom encoder is present, use it
     // Otherwise just use the encodeURIComponent
-    const encode = options.encoder || encodeURIComponent
+    const useCustomEncoder = !!options.encoder;
+    const customEncoder = options.encoder;
 
     const queryParams = [
       // Set the libraryParam if applicable.
@@ -118,11 +119,11 @@ export default class ImgixClient {
         if (value == null) {
           return prev;
         }
-        const encodedKey = encode(key);
+        const encodedKey = useCustomEncoder ? customEncoder(key) : encodeURIComponent(key);
         const encodedValue =
           key.substr(-2) === '64'
-            ? Base64.encodeURI(value)
-            : encode(value);
+          ? useCustomEncoder ? customEncoder(value) : Base64.encodeURI(value)
+          : useCustomEncoder ? customEncoder(value) : encodeURIComponent(value);
         prev.push(`${encodedKey}=${encodedValue}`);
 
         return prev;

--- a/test/test-buildURL.js
+++ b/test/test-buildURL.js
@@ -253,6 +253,14 @@ describe('URL Builder:', function describeSuite() {
 
       assert.strictEqual(result, expectation);
     });
+
+    it('does not base64-encode when a custom encoder is defined', () => {
+      const params = { txt64: 'bG9yZW0gaXBzdW0' };
+      const expectation = '?txt64=bG9yZW0gaXBzdW0';
+      const result = client._buildParams(params, { encoder: (param) => param });
+
+      assert.strictEqual(result, expectation);
+    })
   });
 
   describe('Calling _signParams()', function describeSuite() {

--- a/test/test-buildURL.js
+++ b/test/test-buildURL.js
@@ -388,7 +388,7 @@ describe('URL Builder:', function describeSuite() {
     it('can custom encode the parameter value based on the parameter key', () => {
       const params = { txt64: 'lorem ipsum', txt: 'Hello World' };
       const expectation = '?txt64=bG9yZW0gaXBzdW0&txt=Hello+World';
-      const result = client._buildParams(params, { encoder: (value, key) => key.substr(-2) === '64' ? Base64.encodeURI(value) : value.replace(" ", "+") });
+      const result = client._buildParams(params, { encoder: (value, key) => key && key.substr(-2) === '64' ? Base64.encodeURI(value) : value.replace(" ", "+") });
 
       assert.strictEqual(result, expectation);
     });

--- a/test/test-buildURL.js
+++ b/test/test-buildURL.js
@@ -193,7 +193,7 @@ describe('URL Builder:', function describeSuite() {
         assert.strictEqual(result.substring(1), expectation);
       });
 
-      it("does not encode the path any differently if the option second parameter is passed to the custom encoder", function testSpec() {
+      it("does not alter path encoding when custom encoder optional 'key' parameter is set", function testSpec() {
         const expectation = path.replaceAll(' ', '+');
         const result = client._sanitizePath(path, { encoder: (path, optionalValue) => path.replaceAll(' ', '+')});
 

--- a/test/test-buildURL.js
+++ b/test/test-buildURL.js
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { Base64 } from 'js-base64';
 import ImgixClient from '../src/index.js';
 
 describe('URL Builder:', function describeSuite() {
@@ -260,7 +261,7 @@ describe('URL Builder:', function describeSuite() {
       const result = client._buildParams(params, { encoder: (param) => param });
 
       assert.strictEqual(result, expectation);
-    })
+    });
   });
 
   describe('Calling _signParams()', function describeSuite() {
@@ -382,6 +383,14 @@ describe('URL Builder:', function describeSuite() {
       const expected = 'https://test.imgix.net/unsplash/walrus.jpg?txt=test!(%27)&txt-color=000&txt-size=400&txt-font=Avenir-Black&txt-x=800&txt-y=600'
 
       assert.strictEqual(actual, expected)
-    })
+    });
+
+    it('can custom encode the parameter value based on the parameter key', () => {
+      const params = { txt64: 'lorem ipsum', txt: 'Hello World' };
+      const expectation = '?txt64=bG9yZW0gaXBzdW0&txt=Hello+World';
+      const result = client._buildParams(params, { encoder: (value, key) => key.substr(-2) === '64' ? Base64.encodeURI(value) : value.replace(" ", "+") });
+
+      assert.strictEqual(result, expectation);
+    });
   });
 });

--- a/test/test-buildURL.js
+++ b/test/test-buildURL.js
@@ -182,6 +182,24 @@ describe('URL Builder:', function describeSuite() {
         assert.strictEqual(result.indexOf('%2520'), expectation2);
       });
     });
+
+    describe('with a custom encoder defined', function describeSuite() {
+      const path = 'http://example.com/images and photos/1.png?foo=%20';
+
+      it("encodes the path given custom logic", function testSpec() {
+        const expectation = path.replaceAll(' ', '+');
+        const result = client._sanitizePath(path, { encoder: (path) => path.replaceAll(' ', '+')});
+
+        assert.strictEqual(result.substring(1), expectation);
+      });
+
+      it("does not encode the path any differently if the option second parameter is passed to the custom encoder", function testSpec() {
+        const expectation = path.replaceAll(' ', '+');
+        const result = client._sanitizePath(path, { encoder: (path, optionalValue) => path.replaceAll(' ', '+')});
+
+        assert.strictEqual(result.substring(1), expectation);
+      });
+    });
   });
 
   describe('Calling _buildParams()', function describeSuite() {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,8 +16,8 @@ declare class ImgixClient {
     params?: {},
     options?: { disablePathEncoding?: boolean },
   ): string;
-  _sanitizePath(path: string, options?: { encode?: boolean }): string;
-  _buildParams(params: {}): string;
+  _sanitizePath(path: string, options?: _sanitizePathOptions): string;
+  _buildParams(params: {}, options?: _buildParamsOptions): string;
   _signParams(path: string, queryParams?: {}): string;
   buildSrcSet(path: string, params?: {}, options?: SrcSetOptions): string;
   _buildSrcSetPairs(path: string, params?: {}, options?: SrcSetOptions): string;
@@ -50,6 +50,15 @@ export interface SrcSetOptions {
   devicePixelRatios?: DevicePixelRatio[];
   variableQualities?: VariableQualities;
   disablePathEncoding?: boolean;
+}
+
+export interface _sanitizePathOptions {
+  disablePathEncoding?: boolean,
+  encoder?: (path: string) => string
+}
+
+export interface _buildParamsOptions {
+  encoder?: (value: string, key?: string) => string
 }
 
 export default ImgixClient;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -24,9 +24,10 @@ params = {};
 expectType<string>(client.buildURL('foo/bar/baz', params, buildURLOptions));
 
 expectType<string>(client._sanitizePath(path));
-expectType<string>(client._sanitizePath(path, { encode: false }));
+expectType<string>(client._sanitizePath(path, { disablePathEncoding: true, encoder: (path) => path }));
 
 expectType<string>(client._buildParams(params));
+expectType<string>(client._buildParams(params, { encoder: (value, key) => value }));
 
 expectType<string>(client._signParams(path, params));
 


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description

Before this PR, the `encoder` buildParams option would only be applied to the non-base64 parameters (i.e. parameters whose values did not end in `64`). After this PR, the same encoder will be applied to base64 parameters as well.

It also adds an optional parameter `key` to the encoder which allows users to specify encoding logic conditional to the parameter key. This is helpful if users wish to encode base64 and non-base64 parameters differently.

## Checklist


- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [] ~~Update or add any necessary API documentation (if applicable)~~
- [x] All existing unit tests are still passing (if applicable).
- [] ~~Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).~~
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).
- [] ~~Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.~~
- [] ~~If this is a big feature with breaking changes, consider opening an issue to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.~~