### PR TITLE
ci: pin node to lts and 20.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           command: npm run compile
   deploy:
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:20.2
     steps:
       - checkout
       - node/install-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "current"
+                - "20.2"
                 - "lts"
       - deploy:
           requires:


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->
Node version 20.3 introduces a concurrency issue where the same file is getting accessed by multiple things as part of the rollup process. Unsure as to the root cause, but this commit pins current to 20.2 to resolve the build issues for now.

A future commit should either fix the 20.3 issues.

<!-- Before this PR... -->

<!-- After this PR... -->

<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

